### PR TITLE
[FIX] Replace Chuck to Chucker

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -42,8 +42,6 @@ dependencies {
     // MODULE
     implementation project(':domain')
 
-    // KOTLIN
-    //implementation kotlinStdlib
     // SUPPORT
     api androidXCore
     // COMPONENTS
@@ -62,9 +60,9 @@ dependencies {
 
     // DEBUG TOOLS
     implementation timber
-    debugApi chuckDebug
-    debugTestApi chuckRelease
-    releaseApi chuckRelease
+    debugImplementation chuckerDebug
+    debugTestImplementation chuckerRelease
+    releaseImplementation chuckerRelease
 
     // TEST
     testImplementation junit

--- a/data/src/main/java/com/mikhaellopez/data/net/OkHttpClientFactory.kt
+++ b/data/src/main/java/com/mikhaellopez/data/net/OkHttpClientFactory.kt
@@ -1,8 +1,8 @@
 package com.mikhaellopez.data.net
 
 import android.content.Context
+import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.mikhaellopez.data.BuildConfig
-import com.readystatesoftware.chuck.ChuckInterceptor
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 
@@ -24,7 +24,7 @@ open class OkHttpClientFactory {
 
 
     private fun OkHttpClient.Builder.enableDebugTools(context: Context) {
-        addInterceptor(ChuckInterceptor(context))
+        addInterceptor(ChuckerInterceptor.Builder(context).build())
     }
 
     private fun OkHttpClient.Builder.updateTimeout(read: Long = 60, write: Long = 60) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,10 +52,10 @@ ext {
     retrofitAdapterRxJava       = "com.squareup.retrofit2:adapter-rxjava3:$retrofitVersion"
 
     // DEBUG
-    chuckVersion                = '1.1.0'
+    chuckerVersion              = '3.5.2'
     timber                      = "com.jakewharton.timber:timber:5.0.1"
-    chuckDebug                  = "com.readystatesoftware.chuck:library:$chuckVersion"
-    chuckRelease                = "com.readystatesoftware.chuck:library-no-op:$chuckVersion"
+    chuckerDebug                = "com.github.chuckerteam.chucker:library:$chuckerVersion"
+    chuckerRelease              = "com.github.chuckerteam.chucker:library-no-op:$chuckerVersion"
 
     // TEST
     junit                       = "junit:junit:4.13.2"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -54,6 +54,11 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    configurations {
+        all {
+            exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-ktx'
+        }
+    }
     buildFeatures {
         viewBinding true
     }


### PR DESCRIPTION
Replace Chuck to Chucker to prevent this error on Android API 31:
`Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.`
-> [stackoverflow](https://stackoverflow.com/questions/71361477/targeting-s-version-31-and-above-requires-that-one-of-flag-immutable-or-flag)